### PR TITLE
Add continuous integration

### DIFF
--- a/.github/ranger.yml
+++ b/.github/ranger.yml
@@ -1,7 +1,63 @@
-_extends: reporanger/superpowers
+default:
+  close:
+    delay: 7d
+    comment: ":warning: This has been marked `$LABEL` to be closed in :timer_clock: $DELAY."
+  
+  comment:
+    message: ":label: This has been given `$LABEL`."
+
+labels:
+  wontfix: close
+  invalid: close
+  duplicate:
+    action: close
+    delay: 1d
+  stale:
+    action: close
+    comment: false
+  
+  "merge when passing":
+    action: merge
+    comment: ":customs: This PR will merge after CI checks have passed."
+  dependabot:
+    action: merge
+    comment: ":truck: Auto merge queued by dependabot."
+
+  "good first issue":
+    action: comment
+    delay: 5s
+    message: "Thanks for making your first issue! :slightly_smiling_face:"
+  "new contributor":
+    action: comment
+    delay: 5s
+    message: "Thanks for making your first pull request! :slightly_smiling_face:"
+
+  Hacktoberfest:
+    # only to be given during the month of october
+    action: comment
+    message: "This has been marked for this year's [Hacktoberfest](https://hacktoberfest.digitalocean.com)."
+
+merges:
+  - action: delete_branch
 
 comments:
+  # 'duplicate' label util
+  - action: label
+    pattern: /duplicate of/i
+    labels:
+      - duplicate
+
+  # spam removal
   - action: delete_comment
     pattern: "+1"
   - action: delete_comment
     pattern: /^:.+?:$/i
+  - action: delete_comment
+    pattern: $PROFANITY
+  
+  - action: label
+    user: "dependabot[bot]"
+    labels:
+      - dependabot
+
+commits: []

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,29 @@
+name: Jekyll
+
+on:
+  pull-request:
+    paths-ignore:
+      - docs/**
+
+jobs:
+  # doctor:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: ruby/setup-ruby@v1
+  #       with:
+  #         ruby-version: 2.6
+  #     - run: bundle install
+  #     - run: bundle exec jeykll doctor --trace
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Install Dependencies
+        run: bundle install
+      - name: Build Site (Dry Run)
+        run: bundle exec jekyll build --trace --safe

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,7 +1,7 @@
 name: Jekyll
 
 on:
-  pull-request:
+  pull_request:
     paths-ignore:
       - docs/**
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "jekyll"
+gem "jekyll", ">= 3.9.0"
 
 group :jekyll_plugins do
-  gem "github-pages"
+  gem "github-pages", ">= 207"
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # journey
 
-![build](https://github.com/sudojunior/journey/workflows/build/badge.svg)
+![.github/workflows/jekyll.yml](https://github.com/sudojunior/journey/workflows/.github/workflows/jekyll.yml/badge.svg)
 
 A media database like IMDb, but run through GitHub and deployed on Jekyll.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # journey
 
+![build](https://github.com/sudojunior/journey/workflows/build/badge.svg)
+
 A media database like IMDb, but run through GitHub and deployed on Jekyll.
 
 The _original_ motivation to make this was when observing how limited IMDB was to edit, and then thinking how it could be scaled into a git project where others could learn the ropes while contributing something that would mean something to them as an individual. The outcome is what you see here... although it could do with some improvements.

--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,6 @@ baseurl: /journey
 permalink: pretty
 exclude:
   - README.md
-  - package.json
-  - yarn.lock
   - Gemfile
   - Gemfile.lock
   - LICENSE


### PR DESCRIPTION
GitHub Actions now handles page builds in pull requests to make sure contributions don't cause the deployment to fail.

RepoRanger has had its configuration detached from the `reporangers/superpowers` template and customized to fit this environment.

Further changes include updating the excluded list of file and folder items that no longer exist in the repository, and a badge has been added to the README which shows the status for the most recent build attempt on `master`.

Closes #6 with the implementation of new labels. In the future, an integration like [allcontributors](https://allcontributors.org/) may be handy for those that contribute regularly, as of now the contributions tab under insights will be enough (or use of `git shortlog -s -n` for a summary).