### PR TITLE
Add devicons plugin

### DIFF
--- a/_plugins/DevIcons.rb
+++ b/_plugins/DevIcons.rb
@@ -1,0 +1,31 @@
+require "net/http"
+
+module Jekyll
+  class DevIconTag < Liquid::Tag
+
+    @@icons = {}
+
+    def initialize(tag_name, text, tokens)
+      super
+      brand, variant, @size = text.split " "
+      
+      # defaults
+      # brand - required
+      variant ||= "original"
+
+      # process
+      @path = "https://devicon.dev/devicon.git/icons/#{brand}/#{brand}-#{variant}.svg"
+      if @@icons[@path] == nil
+        puts "[plugin/tag::devicon] New request to devicons for #{brand}-#{variant}"
+        # puts @path
+        @@icons[@path] = Net::HTTP.get(URI(@path))
+      end
+    end
+
+    def render(context)
+      "<span class='devicon devicon-size-#{@size || 64}'>#{@@icons[@path]}</span>"
+    end
+  end
+end
+
+Liquid::Template.register_tag("devicon", Jekyll::DevIconTag)

--- a/_sass/devicons.scss
+++ b/_sass/devicons.scss
@@ -1,0 +1,15 @@
+// devicon svg classes
+
+$sizes: (/* 32, */ 64, 128, 256, 512);
+
+.devicon > svg {
+  width: 32px;
+  height: 32px;
+}
+
+@each $size in $sizes {
+  .devicon.devicon-size-#{$size} > svg {
+    width: #{$size}px;
+    height: #{$size}px;
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,5 @@
+---
+
+---
+
+@import "devicons";


### PR DESCRIPTION
Add a devicons tag to the environment

- Icons requested from devicon.dev are cached by URI path in `@@icons`.
- Default size is 32px (square ratio)
  - Additional sizes available *using built-in css classes*:
   - 64px
   - 128px
   - 256px
   - 512px
- Imported at root using devicons.scss in assets/css

### Tag documentation

- arg0: string as brand target (required)
- arg1: string as variant (optional, defaults to "original")

```html
<!-- Making use of icons from GitHub -->
{% devicon github %}
{% devicon github original %}
{% devicon github original-wordmark %}
```

### Future implementation

- Colors
  *Also take brand colours into account, which may mean custom environment variables would need to be accepted, or config variants using _data files.*
- Additional css sizes?