### PR TITLE
Add 2012 under Q4 Data Milestone

### DIFF
--- a/music/2012/BridgetMendler/ReadyOrNot.md
+++ b/music/2012/BridgetMendler/ReadyOrNot.md
@@ -5,3 +5,4 @@ layout: music-record
 released: 2012-08-07
 uploads:
   youtube: t-njAuS7eTQ
+---

--- a/music/2012/BridgetMendler/ReadyOrNot.md
+++ b/music/2012/BridgetMendler/ReadyOrNot.md
@@ -1,0 +1,7 @@
+---
+title: Ready or Not
+artist: Bridget Mendler
+layout: music-record
+released: 2012-08-07
+uploads:
+  youtube: t-njAuS7eTQ

--- a/music/2012/TaylorSwift/22.md
+++ b/music/2012/TaylorSwift/22.md
@@ -1,0 +1,31 @@
+---
+title: 22
+artist: Taylor Swift
+layout: music-record
+released: 2012-03-12
+uploads:
+  youtube: AgFeZr5ptV8
+covers:
+  # this data accessor is likely to change to phyiscal pages instead
+  # reason being that the pages can be queried and searched for like any other entry on this site
+  - artists:
+      - Kurt Hugo Schnider
+      - Alex Goot
+      - Sam Tsui
+      - Chrissy # currently no linked profile to Against The Current
+      - King The Kid
+    uploads:
+      youtube: Wkecou9v_jk
+  - artist: The Vamps
+    uploads:
+      youtube: _CiyDlUle-8
+  - artists:
+      - target: Jonathan Young
+        connector: ft.
+      - target: Travis Carte
+    uploads:
+      youtube: jVGa83VvXtk
+  - artist: Cimorelli
+    uploads:
+      youtube: BswvBp8Tp3Y
+---

--- a/music/2012/index.md
+++ b/music/2012/index.md
@@ -1,0 +1,4 @@
+---
+layout: overview/category
+category: music
+---

--- a/music/2012/index.md
+++ b/music/2012/index.md
@@ -1,4 +1,4 @@
 ---
-layout: overview/category
-category: music
+layout: overview/year
+year: 2012
 ---


### PR DESCRIPTION
* [3f97a86] '22' includes data on cover records made by other artists
  > this data is likely to move to individual pages once a hierarchial restructure has succeeded as a breaking change